### PR TITLE
Update to 0.3.0 - ClassPlus

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,6 @@
+v0.3.0
+
+- Added the ClassPlus instantiation pattern.
+- See https://mops.one/class-plus
+- Breaking change: You will need to reconfigure your instantiation and the way you pull your environment, but will not need to migrate your state variable as it has the same structure.
+- Update mops versions

--- a/dfx.json
+++ b/dfx.json
@@ -27,6 +27,5 @@
             "subnet_type": "application"
         }
     },
-    "dfx": "0.19.0",
     "version": 1
 }

--- a/example/main.mo
+++ b/example/main.mo
@@ -6,24 +6,80 @@ import Nat "mo:base/Nat";
 import Blob "mo:base/Blob";
 import CertifiedData "mo:base/CertifiedData";
 import CertTree "mo:cert/CertTree";
+import ClassPlus "mo:class-plus";
 
 import D "mo:base/Debug";
 
 import ICRC3 "../src";
 
-shared(init_msg) actor class Example(_args: ICRC3.InitArgs) = this {
+shared(init_msg) actor class Example(_args: ?ICRC3.InitArgs) = this {
 
   stable let cert_store : CertTree.Store = CertTree.newStore();
   let ct = CertTree.Ops(cert_store);
 
-  D.print("initalizing example");
-  stable var icrc3_migration_state = ICRC3.init(ICRC3.initialState() , #v0_1_0(#id), _args, init_msg.caller);
 
   D.print("loading the state");
+  let manager = ClassPlus.ClassPlusInitializationManager(init_msg.caller, Principal.fromActor(this), true);
 
-  
 
-  let #v0_1_0(#data(icrc3_state_current)) = icrc3_migration_state;
+  public type Environment = {
+    canister : () -> Principal;
+    get_time : () -> Int;
+    refresh_state: () -> ICRC3.CurrentState;
+  };
+
+  func get_environment() : Environment {
+    {
+      canister = get_canister;
+      get_time = get_time;
+      refresh_state = func() : ICRC3.CurrentState{
+        icrc3().get_state();
+      };
+    };
+  };
+
+    private func get_icrc3_environment() : ICRC3.Environment{
+      {
+        updated_certification = ?updated_certification;
+        get_certificate_store = ?get_certificate_store;
+      };
+    };
+
+
+  stable var icrc3_migration_state = ICRC3.initialState();
+
+  private func get_certificate_store() : CertTree.Store {
+    D.print("returning cert store " # debug_show(cert_store));
+    return cert_store;
+  };
+
+  private func updated_certification(cert: Blob, lastIndex: Nat) : Bool{
+
+    D.print("updating the certification " # debug_show(CertifiedData.getCertificate(), ct.treeHash()));
+    ct.setCertifiedData();
+    D.print("did the certification " # debug_show(CertifiedData.getCertificate()));
+    return true;
+  };
+
+  let icrc3 = ICRC3.Init<system>({
+    manager = manager;
+    initialState = icrc3_migration_state;
+    args = _args;
+    pullEnvironment = ?get_icrc3_environment;
+    onInitialize = ?(func(newClass: ICRC3.ICRC3) : async*(){
+       if(newClass.stats().supportedBlocks.size() == 0){
+          newClass.update_supported_blocks([
+            {block_type = "uupdate_user"; url="https://git.com/user"},
+            {block_type ="uupdate_role"; url="https://git.com/user"},
+            {block_type ="uupdate_use_role"; url="https://git.com/user"}
+          ])
+        };
+    });
+    onStorageChange = func(state: ICRC3.State){
+      icrc3_migration_state := state;
+    };
+  });
+
 
   D.print("loaded the state");
 
@@ -41,10 +97,6 @@ shared(init_msg) actor class Example(_args: ICRC3.InitArgs) = this {
     };
   };
 
-  private func get_certificate_store() : CertTree.Store {
-    D.print("returning cert store " # debug_show(cert_store));
-    return cert_store;
-  };
 
   private func get_time() : Int{
       //note: you may want to implement a testing framework where you can set this time manually
@@ -57,60 +109,6 @@ shared(init_msg) actor class Example(_args: ICRC3.InitArgs) = this {
           };
       }; */
     Time.now();
-  };
-
-  func get_state() : ICRC3.CurrentState{
-    return icrc3_state_current;
-  };
-
-  public type Environment = {
-    canister : () -> Principal;
-    get_time : () -> Int;
-    refresh_state: () -> ICRC3.CurrentState;
-  };
-
-  func get_environment() : Environment {
-    {
-      canister = get_canister;
-      get_time = get_time;
-      refresh_state = get_state;
-    };
-  };
-
-  private var _icrc3 : ?ICRC3.ICRC3 = null;
-
-  private func get_icrc3_environment() : ICRC3.Environment{
-    ?{
-      updated_certification = ?updated_certification;
-      get_certificate_store = ?get_certificate_store;
-    };
-  };
-
-  private func updated_certification(cert: Blob, lastIndex: Nat) : Bool{
-
-    D.print("updating the certification " # debug_show(CertifiedData.getCertificate(), ct.treeHash()));
-    ct.setCertifiedData();
-    D.print("did the certification " # debug_show(CertifiedData.getCertificate()));
-    return true;
-  };
-
-  func icrc3() : ICRC3.ICRC3 {
-    switch(_icrc3){
-      case(null){
-        let initclass : ICRC3.ICRC3 = ICRC3.ICRC3(?icrc3_migration_state, Principal.fromActor(this), get_icrc3_environment());
-        _icrc3 := ?initclass;
-
-        if(initclass.stats().supportedBlocks.size() == 0){
-          initclass.update_supported_blocks([
-            {block_type = "uupdate_user"; url="https://git.com/user"},
-            {block_type ="uupdate_role"; url="https://git.com/user"},
-            {block_type ="uupdate_use_role"; url="https://git.com/user"}
-          ])
-        };
-        initclass;
-      };
-      case(?val) val;
-    };
   };
 
   public query func icrc3_get_blocks(args: ICRC3.GetBlocksArgs) : async ICRC3.GetBlocksResult{

--- a/mops.toml
+++ b/mops.toml
@@ -1,19 +1,20 @@
 [package]
 name = "icrc3-mo"
-version = "0.2.6"
+version = "0.3.0"
 description = "icrc3 for motoko"
 repository = "https://github.com/PanIndustrial-Org/icrc3.mo"
 keywords = [ "ledger", "transactions", "log" ]
 license = "MIT"
 
 [dependencies]
-base = "0.11.1"
+base = "0.14.6"
 stable-write-only = "https://github.com/skilesare/StableWriteOnly.mo#v0.1.0@02e9aac74bdbed86b52ebed985d82b6ef66a76d8"
 map9 = "https://github.com/ZhenyaUsenko/motoko-hash-map#v9.0.1@10b68f6ea8df5e72dfa4c07a50c8bb60a916c233"
-vector = "0.2.0"
-sha2 = "0.0.5"
+vector = "0.4.1"
+sha2 = "0.1.0"
 rep-indy-hash = "0.1.1"
 cert = "https://github.com/nomeata/ic-certification#v0.1.3@c403ffec0a60f658a1009976c785aa567ff0da77"
+class-plus = "0.0.1"
 
 [dev-dependencies]
 test = "1.2.0"

--- a/src/migrations/lib.mo
+++ b/src/migrations/lib.mo
@@ -4,20 +4,22 @@ import v0_1_0 "./v000_001_000";
 import D "mo:base/Debug";
 
 module {
+
+  public let debug_channel = {
+    announce = false;
+  };
+
   let upgrades = [
     v0_1_0.upgrade,
-    // do not forget to add your new migration upgrade method here
-  ];
 
-  let downgrades = [
-    v0_1_0.downgrade,
-    // do not forget to add your new migration downgrade method here
+    // do not forget to add your new migration upgrade method here
   ];
 
   func getMigrationId(state: MigrationTypes.State): Nat {
     return switch (state) {
       case (#v0_0_0(_)) 0;
       case (#v0_1_0(_)) 1;
+
       // do not forget to add your new migration id here
       // should be increased by 1 as it will be later used as an index to get upgrade/downgrade methods
     };
@@ -26,26 +28,35 @@ module {
   public func migrate(
     prevState: MigrationTypes.State, 
     nextState: MigrationTypes.State, 
-    args: MigrationTypes.Args,
-    caller: Principal
+    args: ?MigrationTypes.Args,
+    caller: Principal,
+    canister: Principal
   ): MigrationTypes.State {
 
-   
+   // debug if (debug_channel.announce) D.print("in migrate" # debug_show(prevState));
     var state = prevState;
     var migrationId = getMigrationId(prevState);
-    
+    debug if (debug_channel.announce) D.print("getting migration id");
     let nextMigrationId = getMigrationId(nextState);
+    debug if (debug_channel.announce) D.print(debug_show(nextMigrationId));
 
-    while (migrationId != nextMigrationId) {
-      
-      let migrate = if (nextMigrationId > migrationId) upgrades[migrationId] else downgrades[migrationId - 1];
-      
+    while (nextMigrationId > migrationId) {
+      debug if (debug_channel.announce) D.print("in upgrade while" # debug_show((nextMigrationId, migrationId)));
+      let migrate = upgrades[migrationId];
+      debug if (debug_channel.announce) D.print("upgrade should have run");
       migrationId := if (nextMigrationId > migrationId) migrationId + 1 else migrationId - 1;
 
-      state := migrate(state, args, caller);
-      
+      state := migrate(state, args, caller, canister);
     };
 
     return state;
+  };
+
+  public let migration = {
+    initialState = #v0_0_0(#data);
+    //update your current state version
+    currentStateVersion = #v0_1_0(#id);
+    getMigrationId = getMigrationId;
+    migrate = migrate;
   };
 };

--- a/src/migrations/types.mo
+++ b/src/migrations/types.mo
@@ -1,5 +1,4 @@
 import v0_1_0 "./v000_001_000/types";
-import Int "mo:base/Int";
 
 
 module {
@@ -8,11 +7,12 @@ module {
   // instead of importing it from migration folder itself
   public let Current = v0_1_0;
 
-  public type Args = ?v0_1_0.InitArgs;
+  public type Args = v0_1_0.InitArgs;
 
   public type State = {
     #v0_0_0: {#id; #data};
     #v0_1_0: {#id; #data:  v0_1_0.State};
+
     // do not forget to add your new migration state types here
   };
 };

--- a/src/migrations/v000_000_000/lib.mo
+++ b/src/migrations/v000_000_000/lib.mo
@@ -2,14 +2,10 @@ import MigrationTypes "../types";
 import D "mo:base/Debug";
 
 module {
-  public func upgrade(prevmigration_state: MigrationTypes.State, args: MigrationTypes.Args, caller: Principal): MigrationTypes.State {
+  public func upgrade(prevmigration_state: MigrationTypes.State, args: MigrationTypes.Args, caller: Principal, canister: Principal): MigrationTypes.State {
 
     return #v0_0_0(#data);
   };
 
-  public func downgrade(prev_migration_state: MigrationTypes.State, args: MigrationTypes.Args, caller: Principal): MigrationTypes.State {
-
-    return #v0_0_0(#data);
-  };
 
 };

--- a/src/migrations/v000_001_000/lib.mo
+++ b/src/migrations/v000_001_000/lib.mo
@@ -2,6 +2,7 @@ import MigrationTypes "../types";
 import v0_1_0 "types";
 
 import D "mo:base/Debug";
+import Principal "mo:base/Principal";
 
 import Vec "mo:vector";
 import Map "mo:map9/Map";
@@ -10,7 +11,7 @@ module {
 
   type Transaction = v0_1_0.Transaction;
 
-  public func upgrade(prevmigration_state: MigrationTypes.State, args: MigrationTypes.Args, caller: Principal): MigrationTypes.State {
+  public func upgrade(prevmigration_state: MigrationTypes.State, args: ?MigrationTypes.Args, caller: Principal, canister: Principal): MigrationTypes.State {
 
     
 
@@ -56,9 +57,6 @@ module {
     return #v0_1_0(#data(state));
   };
 
-  public func downgrade(prev_migration_state: MigrationTypes.State, args: MigrationTypes.Args, caller: Principal): MigrationTypes.State {
 
-    return #v0_0_0(#data);
-  };
 
 };

--- a/src/migrations/v000_001_000/types.mo
+++ b/src/migrations/v000_001_000/types.mo
@@ -15,10 +15,12 @@ import Nat32 "mo:base/Nat32";
 import D "mo:base/Debug";
 import SW "mo:stable-write-only";
 import Map "mo:map9/Map";
+import CertTreeLib "mo:cert/CertTree";
 
 module {
 
   //public let CandyTypes = CandyTypesLib;
+  public let CertTree = CertTreeLib;
 
   public type Value = { 
     #Blob : Blob; 
@@ -230,5 +232,12 @@ module {
       archiveControllers : ??[Principal];
       supportedBlocks : [BlockType];
     };
+
+    public type Environment = {
+      updated_certification : ?((Blob, Nat) -> Bool); //called when a certification has been made
+      get_certificate_store : ?(() -> CertTree.Store); //needed to pass certificate store to the class
+    };
+
+    
 
 };

--- a/src/service.mo
+++ b/src/service.mo
@@ -63,6 +63,8 @@ module
     icrc3_get_archives : query (GetArchivesArgs) -> async (GetArchivesResult) ;
     icrc3_get_tip_certificate : query () -> async (?DataCertificate);
     icrc3_get_blocks : query (GetBlocksArgs) -> async (GetBlocksResult);
-     icrc3_supported_block_types: query () -> async [BlockType];
+    icrc3_supported_block_types: query () -> async [BlockType];
+    get_tip_certificate : query () -> async DataCertificate;
+
   };
 }


### PR DESCRIPTION
v0.3.0

- Added the ClassPlus instantiation pattern.
- See https://mops.one/class-plus
- Breaking change: You will need to reconfigure your instantiation and the way you pull your environment, but will not need to migrate your state variable as it has the same structure.
- Update mops versions